### PR TITLE
BlameJared maven should use https and subdomain

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ minecraft {
 
 repositories {
     maven { url 'http://dvs1.progwml6.com/files/maven' }
-    maven { url "http://blamejared.com/maven" }
+    maven { url "https://maven.blamejared.com" }
 	maven { url "http://www.ryanliptak.com/maven/" }
     maven { url "http://maven.amadornes.com/" }
 }


### PR DESCRIPTION
While this isn't an issue right now, if I ever need to move the maven folder, or need to direct the subdomain to a different server, this will be an issue.

http -> https is just an upgrade